### PR TITLE
prevent submitting bad data from search bar

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -20,7 +20,13 @@ class RestaurantsController < ApplicationController
   end
 
   def search
-    restaurant = Restaurant.find(params[:restaurant_id])
+    restaurant = nil
+    id = params[:restaurant_id]
+
+    if id.match(/\d+/)
+      restaurant = Restaurant.find(id)
+    end
+
     if restaurant
       flash[:notice] = nil # Bandaid. Figure out why it stays set from the `else` branch
       redirect_to restaurant_path(restaurant.id)

--- a/app/javascript/packs/restaurant_autocomplete.jsx
+++ b/app/javascript/packs/restaurant_autocomplete.jsx
@@ -31,6 +31,15 @@ class Autocomplete extends Component {
   onChange = e => {
     const { suggestions } = this.props;
     const userInput = e.currentTarget.value;
+    const submitNode = document.getElementById('search-submit')
+
+    if (userInput === '') {
+      submitNode.disabled = true
+      submitNode.style.cursor = 'not-allowed'
+    } else {
+      submitNode.disabled = false
+      submitNode.style.cursor = ''
+    }
 
     // Filter our suggestions that don't contain the user's input
     const filteredSuggestions = suggestions.filter(
@@ -69,13 +78,18 @@ class Autocomplete extends Component {
     const { activeSuggestion, filteredSuggestions } = this.state;
 
     // User pressed the enter key, update the input and close the
-    // suggestions
+    // suggestions, then submit the form
     if (e.keyCode === 13) {
       this.setState({
         activeSuggestion: 0,
         showSuggestions: false,
-        userInput: filteredSuggestions[activeSuggestion.name]
+        userInput: filteredSuggestions[activeSuggestion].name
       });
+
+      const form = document.getElementById('restaurant-form')
+      const idField = document.getElementById('restaurant-id')
+      idField.value = filteredSuggestions[activeSuggestion].id
+      form.submit()
     }
     // User pressed the up arrow, decrement the index
     else if (e.keyCode === 38) {

--- a/app/javascript/packs/restaurant_search.jsx
+++ b/app/javascript/packs/restaurant_search.jsx
@@ -4,8 +4,12 @@ import ReactDOM from 'react-dom'
 import Autocomplete from "./restaurant_autocomplete";
 
 document.addEventListener('DOMContentLoaded', () => {
-  const node = document.getElementById('restaurants_data')
+  const node = document.getElementById('restaurants-data')
   const data = JSON.parse(node.getAttribute('data'))
+
+  const submitNode = document.getElementById('search-submit')
+  submitNode.disabled = true
+  submitNode.style.cursor = 'not-allowed'
 
   ReactDOM.render(
     <Autocomplete suggestions={data} />,

--- a/app/models/rapid_api_quotum.rb
+++ b/app/models/rapid_api_quotum.rb
@@ -1,6 +1,9 @@
 class RapidApiQuotum < ApplicationRecord
+  MAX_QUOTA = 500
+
   class << self
     def remaining
+      record = first_or_create(requests_remaining: MAX_QUOTA)
       first.requests_remaining
     end
 

--- a/app/views/welcome/home.html.haml
+++ b/app/views/welcome/home.html.haml
@@ -1,13 +1,12 @@
 .page-body-content
   .cover.main
     .logo
-      = link_to image_tag( 'Logo-web.png'), root_path, class: "home-target"
-
+      = link_to image_tag('Logo-web.png'), root_path, class: "home-target"
 
     = form_tag(search_restaurants_path, id: 'restaurant-form') do
       .search-form#search-input-field
       =hidden_field_tag :restaurant_id, nil, id: 'restaurant-id'
-      =submit_tag 'Search', class: 'btn-success'
+      =submit_tag 'Search', class: 'btn-success', id: 'search-submit'
 
   .spacer
 
@@ -44,7 +43,6 @@
       %h3 Step 3
       %p Order Again!
 
--# This is just used to pass data to the restaurant_search React component
-#restaurants_data{data: @restaurants.to_json}
-
+-# This is not visible and is just used to pass data to the restaurant_search React component
+#restaurants-data{data: @restaurants.to_json}
 = javascript_pack_tag 'restaurant_search'


### PR DESCRIPTION
Users could click on submit with an empty or incomplete name and see a 500 error page.
Fixed by preventing users from clicking the button and handling bad input on server side.